### PR TITLE
增加仅代理局域网与国外网址。

### DIFF
--- a/only_local_foreign.ini
+++ b/only_local_foreign.ini
@@ -1,0 +1,10 @@
+;设置规则标志位
+surge_ruleset=直接放行,rules/LocalAreaNetwork.list
+surge_ruleset=直接放行,[]GEOIP,CN
+surge_ruleset=翻墙吧,[]MATCH
+;设置规则标志位
+
+;设置分组标志位
+custom_proxy_group=翻墙吧`load-balance`中继`http://www.gstatic.com/generate_204`600
+custom_proxy_group=直接放行`select`[]DIRECT
+;设置分组标志位


### PR DESCRIPTION
增加类似SSR的绕过局域网与国内。
代理方式为负载均衡。
经测试，负载均衡方式可以达到比较理想的y2b观看速度。